### PR TITLE
Add race analysis and export features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # relay-lap-counter
 Android app for tracking laps in a one-hour relay run. Multiple teams can record laps by tapping buttons with their start numbers.
+
+## Features
+
+- Dynamically created buttons fill the screen so each team has a large rectangular target.
+- Lap times are recorded per start number and additional distance not completing a full lap can be entered afterwards.
+- Total distance is calculated as `laps x 400m + extra meters` and results can be sorted to show the best team on top.
+- Tapping a result reveals a list of lap times for that start number.
+- Recorded data (start number, lap times and remaining meters) can be exported via the share menu.

--- a/app/src/main/java/com/example/timedbuttonlogger/MainActivity.kt
+++ b/app/src/main/java/com/example/timedbuttonlogger/MainActivity.kt
@@ -7,6 +7,10 @@ import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
+import android.text.Editable
+import android.text.TextWatcher
+import android.text.InputType
+import android.content.Intent
 import android.view.View
 import android.widget.*
 import androidx.appcompat.app.AlertDialog
@@ -19,12 +23,21 @@ class MainActivity : AppCompatActivity() {
     private lateinit var reviewLayout: View
     private lateinit var inputNumbers: EditText
     private lateinit var timerText: TextView
-    private lateinit var logText: TextView
     private lateinit var buttonContainer: LinearLayout
+    private lateinit var reviewContainer: LinearLayout
+    private lateinit var analyzeButton: Button
+    private lateinit var exportButton: Button
 
     private val handler = Handler(Looper.getMainLooper())
     private var sessionStart = 0L
-    private val logEntries = mutableListOf<String>()
+    private val runners = mutableMapOf<Int, Runner>()
+
+    data class Runner(val number: Int) {
+        val lapTimes = mutableListOf<Long>()
+        var lastTime = 0L
+        var restMeters = 0
+        fun totalDistance(): Int = lapTimes.size * 400 + restMeters
+    }
 
     private val timerRunnable = object : Runnable {
         override fun run() {
@@ -43,12 +56,16 @@ class MainActivity : AppCompatActivity() {
         reviewLayout = findViewById(R.id.reviewLayout)
         inputNumbers = findViewById(R.id.inputNumbers)
         timerText = findViewById(R.id.timerText)
-        logText = findViewById(R.id.logText)
         buttonContainer = findViewById(R.id.buttonContainer)
+        reviewContainer = findViewById(R.id.reviewContainer)
+        analyzeButton = findViewById(R.id.analyzeButton)
+        exportButton = findViewById(R.id.exportButton)
 
         findViewById<Button>(R.id.startButton).setOnClickListener { startSession() }
         findViewById<Button>(R.id.endButton).setOnClickListener { confirmEnd() }
         findViewById<Button>(R.id.restartButton).setOnClickListener { showConfig() }
+        analyzeButton.setOnClickListener { analyzeResults() }
+        exportButton.setOnClickListener { exportResults() }
     }
 
     private fun startSession() {
@@ -62,16 +79,19 @@ class MainActivity : AppCompatActivity() {
         activeLayout.visibility = View.VISIBLE
 
         buttonContainer.removeAllViews()
-        logEntries.clear()
+        runners.clear()
         sessionStart = SystemClock.elapsedRealtime()
         handler.post(timerRunnable)
 
         numbers.forEach { num ->
+            val runner = Runner(num)
+            runners[num] = runner
             val btn = Button(this).apply {
                 text = num.toString()
                 layoutParams = LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
+                    0,
+                    1f
                 )
                 setBackgroundColor(Color.GREEN)
             }
@@ -81,7 +101,9 @@ class MainActivity : AppCompatActivity() {
                 btn.setBackgroundColor(Color.GREEN)
                 animator.start()
                 val elapsed = SystemClock.elapsedRealtime() - sessionStart
-                logEntries.add("$num, ${formatTime(elapsed)}")
+                val lap = elapsed - runner.lastTime
+                runner.lastTime = elapsed
+                runner.lapTimes.add(lap)
             }
             buttonContainer.addView(btn)
             animator.start()
@@ -109,7 +131,38 @@ class MainActivity : AppCompatActivity() {
         handler.removeCallbacks(timerRunnable)
         activeLayout.visibility = View.GONE
         reviewLayout.visibility = View.VISIBLE
-        logText.text = logEntries.joinToString("\n")
+        reviewContainer.removeAllViews()
+        runners.values.forEach { runner ->
+            val row = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(8, 8, 8, 8)
+            }
+            val numberText = TextView(this).apply {
+                text = runner.number.toString()
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+            val restInput = EditText(this).apply {
+                hint = "Rest m"
+                inputType = InputType.TYPE_CLASS_NUMBER
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+            val totalText = TextView(this).apply {
+                text = "Total: ${runner.totalDistance()} m"
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+            restInput.addTextChangedListener(object : TextWatcher {
+                override fun afterTextChanged(s: Editable?) {
+                    runner.restMeters = s.toString().toIntOrNull() ?: 0
+                    totalText.text = "Total: ${runner.totalDistance()} m"
+                }
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            })
+            row.addView(numberText)
+            row.addView(restInput)
+            row.addView(totalText)
+            reviewContainer.addView(row)
+        }
     }
 
     private fun showConfig() {
@@ -117,6 +170,48 @@ class MainActivity : AppCompatActivity() {
         activeLayout.visibility = View.GONE
         configLayout.visibility = View.VISIBLE
         inputNumbers.setText("")
+        reviewContainer.removeAllViews()
+        runners.clear()
+    }
+
+    private fun analyzeResults() {
+        val sorted = runners.values.sortedByDescending { it.totalDistance() }
+        reviewContainer.removeAllViews()
+        sorted.forEach { runner ->
+            val tv = TextView(this).apply {
+                text = "Start ${runner.number}: ${runner.totalDistance()} m"
+                setPadding(8, 8, 8, 8)
+            }
+            tv.setOnClickListener { showLapTimes(runner) }
+            reviewContainer.addView(tv)
+        }
+    }
+
+    private fun exportResults() {
+        val sb = StringBuilder()
+        runners.values.forEach { runner ->
+            sb.append("Start ${runner.number}: ${runner.totalDistance()} m\n")
+            runner.lapTimes.forEachIndexed { index, t ->
+                sb.append("  Runde ${index + 1}: ${formatTime(t)}\n")
+            }
+            sb.append("  Rest: ${runner.restMeters} m\n\n")
+        }
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, sb.toString())
+        }
+        startActivity(Intent.createChooser(sendIntent, "Exportieren"))
+    }
+
+    private fun showLapTimes(runner: Runner) {
+        val msg = runner.lapTimes.mapIndexed { index, t ->
+            "Runde ${index + 1}: ${formatTime(t)}"
+        }.joinToString("\n")
+        AlertDialog.Builder(this)
+            .setTitle("Start ${runner.number}")
+            .setMessage(msg)
+            .setPositiveButton("OK", null)
+            .show()
     }
 
     private fun formatTime(ms: Long): String {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -57,11 +57,22 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1">
-            <TextView
-                android:id="@+id/logText"
+            <LinearLayout
+                android:id="@+id/reviewContainer"
+                android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
         </ScrollView>
+        <Button
+            android:id="@+id/analyzeButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Auswertung"/>
+        <Button
+            android:id="@+id/exportButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Exportieren"/>
         <Button
             android:id="@+id/restartButton"
             android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- Display buttons that evenly fill the screen for each start number
- Allow entering extra meters and compute total distance per runner
- Sort results, show lap times, and export session data

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.android.application', version: '8.3.2', apply: false] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae01693640832fa0bb1103a4f52ff2