### PR TITLE
Add dynamic start number inputs, grid buttons, and lap graph

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,4 +32,5 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.13.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.gridlayout:gridlayout:1.0.0'
 }

--- a/app/src/main/java/com/example/timedbuttonlogger/MainActivity.kt
+++ b/app/src/main/java/com/example/timedbuttonlogger/MainActivity.kt
@@ -3,6 +3,8 @@ package com.example.timedbuttonlogger
 import android.animation.ArgbEvaluator
 import android.animation.ValueAnimator
 import android.graphics.Color
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -10,9 +12,11 @@ import android.os.SystemClock
 import android.text.Editable
 import android.text.TextWatcher
 import android.text.InputType
+import android.content.Context
 import android.content.Intent
 import android.view.View
 import android.widget.*
+import androidx.gridlayout.widget.GridLayout
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import java.util.Locale
@@ -21,9 +25,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var configLayout: View
     private lateinit var activeLayout: View
     private lateinit var reviewLayout: View
-    private lateinit var inputNumbers: EditText
+    private lateinit var startNumbersContainer: LinearLayout
     private lateinit var timerText: TextView
-    private lateinit var buttonContainer: LinearLayout
+    private lateinit var buttonContainer: GridLayout
     private lateinit var reviewContainer: LinearLayout
     private lateinit var analyzeButton: Button
     private lateinit var exportButton: Button
@@ -54,7 +58,7 @@ class MainActivity : AppCompatActivity() {
         configLayout = findViewById(R.id.configLayout)
         activeLayout = findViewById(R.id.activeLayout)
         reviewLayout = findViewById(R.id.reviewLayout)
-        inputNumbers = findViewById(R.id.inputNumbers)
+        startNumbersContainer = findViewById(R.id.startNumbersContainer)
         timerText = findViewById(R.id.timerText)
         buttonContainer = findViewById(R.id.buttonContainer)
         reviewContainer = findViewById(R.id.reviewContainer)
@@ -66,12 +70,37 @@ class MainActivity : AppCompatActivity() {
         findViewById<Button>(R.id.restartButton).setOnClickListener { showConfig() }
         analyzeButton.setOnClickListener { analyzeResults() }
         exportButton.setOnClickListener { exportResults() }
+
+        addNumberInput()
+    }
+
+    private fun addNumberInput() {
+        val et = EditText(this).apply {
+            inputType = InputType.TYPE_CLASS_NUMBER
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+        }
+        et.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable?) {
+                if (!s.isNullOrEmpty() && startNumbersContainer.indexOfChild(et) == startNumbersContainer.childCount - 1) {
+                    addNumberInput()
+                }
+            }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+        })
+        startNumbersContainer.addView(et)
     }
 
     private fun startSession() {
-        val numbers = inputNumbers.text.toString()
-            .split(',', ' ', '\n')
-            .mapNotNull { it.trim().toIntOrNull() }
+        val numbers = mutableListOf<Int>()
+        for (i in 0 until startNumbersContainer.childCount) {
+            val et = startNumbersContainer.getChildAt(i) as EditText
+            val num = et.text.toString().trim().toIntOrNull()
+            if (num != null) numbers.add(num)
+        }
         if (numbers.isEmpty()) return
 
         configLayout.visibility = View.GONE
@@ -80,19 +109,23 @@ class MainActivity : AppCompatActivity() {
 
         buttonContainer.removeAllViews()
         runners.clear()
+        val columns = kotlin.math.ceil(kotlin.math.sqrt(numbers.size.toDouble())).toInt()
+        buttonContainer.columnCount = columns
         sessionStart = SystemClock.elapsedRealtime()
         handler.post(timerRunnable)
 
-        numbers.forEach { num ->
+        numbers.forEachIndexed { index, num ->
             val runner = Runner(num)
             runners[num] = runner
             val btn = Button(this).apply {
                 text = num.toString()
-                layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    0,
-                    1f
-                )
+                layoutParams = GridLayout.LayoutParams(
+                    GridLayout.spec(index / columns, 1f),
+                    GridLayout.spec(index % columns, 1f)
+                ).apply {
+                    width = 0
+                    height = 0
+                }
                 setBackgroundColor(Color.GREEN)
             }
             val animator = createColorAnimator(btn)
@@ -169,7 +202,8 @@ class MainActivity : AppCompatActivity() {
         reviewLayout.visibility = View.GONE
         activeLayout.visibility = View.GONE
         configLayout.visibility = View.VISIBLE
-        inputNumbers.setText("")
+        startNumbersContainer.removeAllViews()
+        addNumberInput()
         reviewContainer.removeAllViews()
         runners.clear()
     }
@@ -204,12 +238,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun showLapTimes(runner: Runner) {
-        val msg = runner.lapTimes.mapIndexed { index, t ->
-            "Runde ${index + 1}: ${formatTime(t)}"
-        }.joinToString("\n")
+        val graph = LapGraphView(this, runner.lapTimes)
         AlertDialog.Builder(this)
             .setTitle("Start ${runner.number}")
-            .setMessage(msg)
+            .setView(graph)
             .setPositiveButton("OK", null)
             .show()
     }
@@ -219,5 +251,26 @@ class MainActivity : AppCompatActivity() {
         val minutes = totalSeconds / 60
         val seconds = totalSeconds % 60
         return String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+
+    private class LapGraphView(context: Context, private val laps: List<Long>) : View(context) {
+        private val paint = Paint().apply { color = Color.BLUE }
+
+        override fun onDraw(canvas: Canvas) {
+            super.onDraw(canvas)
+            if (laps.isEmpty()) return
+            val max = laps.maxOrNull()!!.toFloat()
+            val barWidth = width.toFloat() / laps.size
+            laps.forEachIndexed { index, lap ->
+                val barHeight = (lap / max) * height
+                canvas.drawRect(
+                    index * barWidth,
+                    height - barHeight,
+                    (index + 1) * barWidth,
+                    height.toFloat(),
+                    paint
+                )
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -9,11 +9,11 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-        <EditText
-            android:id="@+id/inputNumbers"
+        <LinearLayout
+            android:id="@+id/startNumbersContainer"
+            android:orientation="vertical"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="Enter numbers separated by commas"/>
+            android:layout_height="wrap_content" />
         <Button
             android:id="@+id/startButton"
             android:layout_width="match_parent"
@@ -34,12 +34,12 @@
             android:layout_height="wrap_content"
             android:textSize="24sp"
             android:gravity="center"/>
-        <LinearLayout
+        <androidx.gridlayout.widget.GridLayout
             android:id="@+id/buttonContainer"
-            android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1"/>
+            android:layout_weight="1"
+            android:columnCount="1"/>
         <Button
             android:id="@+id/endButton"
             android:layout_width="match_parent"


### PR DESCRIPTION
## Summary
- Allow entering multiple start numbers with auto-expanding input fields
- Arrange runner buttons in a squarish grid and animate laps
- Display lap times as a simple bar chart in analytics

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1ea38630832f82a44b9e6be4d0d7